### PR TITLE
Changes to the build process

### DIFF
--- a/src/bexpproc/SConstruct
+++ b/src/bexpproc/SConstruct
@@ -14,7 +14,7 @@ ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
 
 # library dependancies
 # build ncomm library
-SConscript(os.path.join(ncommPath, 'SConstruct'))
+# SConscript(os.path.join(ncommPath, 'SConstruct'))
 
 ncommHdrList = [ 'errLogLib.h',
                  'eventHandler.h',

--- a/src/bin/SConstruct
+++ b/src/bin/SConstruct
@@ -9,7 +9,7 @@ platform = sys.platform
 SConscript('SConstruct.bin')
 SConscript('SConstruct.diffparams')
 SConscript('SConstruct.diffshims')
-SConscript('SConstruct.dps_ps_gen')
+# SConscript('SConstruct.dps_ps_gen')  done by bpsglib
 SConscript('SConstruct.pbox')
 SConscript('SConstruct.send2vnmr')
 # SConscript('SConstruct.tabc')

--- a/src/bpsg/makeuserpsg.lnx
+++ b/src/bpsg/makeuserpsg.lnx
@@ -9,9 +9,9 @@ USR_PSG_DIR= $(vnmruser)/psg/
 
 #-----  Normal operational compile flags
 CDEFINE= -DLINUX -DNESSIE -Wno-format
-CFLAGS= -O -fPIC -m32 -c
+CFLAGS= -O -fPIC -m64 -c
 CPPFLAGS= -U_FORTIFY_SOURCE
-LDFLAGS= -shared -m32
+LDFLAGS= -shared -m64
 COMPILE.c= $(CC) $(CFLAGS) $(CPPFLAGS) $(CDEFINE) -c
 LINK.c= $(CC) $(LDFLAGS)
 
@@ -82,7 +82,7 @@ ALLOBJ= $(PSG_OBJ) $(DPS_DUMMY_OBJ)
 #-----  All sources and headers are required for compilation
 ALLSRC=	$(PSG_SRC) $(PSG_HDR) $(DPS_DUMMY_SRC)
 ALL_C_SRC=$(PSG_SRC) $(DPS_DUMMY_SRC)
-LIBS=	-lm
+LIBS=	-lm -lacqcomm
 
 
 #------------------------------------------------------------------------
@@ -130,7 +130,7 @@ maclibpsglib.a : $(PSG_OBJ)
 	@(umask 2; libtool -static -o libpsglib.a $(PSG_OBJ) )
 
 libpsglib.so : $(PSG_OBJ)
-	@(umask 2; $(LINK.c) -Wl,-soname,$@ -o $@.$(SO_LIB_VER) $(PSG_OBJ) $(CND_PSG_OBJ))
+	@(umask 2; $(LINK.c) -Wl,-soname,$@,-rpath,'/vnmr/lib' -L/vnmr/lib -o $@.$(SO_LIB_VER) $(PSG_OBJ) $(CND_PSG_OBJ) $(LIBS))
 	@(umask 2; ln -s $@.$(SO_LIB_VER) $@)
 
 depend: src

--- a/src/bpsglib/SConstruct
+++ b/src/bpsglib/SConstruct
@@ -17,9 +17,10 @@ ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
 # os.system(cmd)
 
 # dependancies
-binPath = os.path.join(cwd, os.pardir, 'bin')
-#SConscript(os.path.join(binPath, 'SConstruct'))
-cmd='cd ../bin;scons -f SConstruct.dps_ps_gen'
+if os.path.exists('/usr/bin/scons'):
+   cmd='cd ../bin;scons -f SConstruct.dps_ps_gen'
+else:
+   cmd='cd ../bin;scons-3 -f SConstruct.dps_ps_gen'
 os.system(cmd)
 
 psgPath = os.path.join(cwd, os.pardir, 'bpsg')

--- a/src/infoproc/SConstruct
+++ b/src/infoproc/SConstruct
@@ -39,9 +39,15 @@ buildMethods.makeSymLinks(env, procTarget, cwd, vwacqPath, vwacqHdrList)
 buildMethods.makeSymLinks(env, procTarget, cwd, expProcPath, expProcHdrList)
 buildMethods.makeSymLinks(env, procTarget, cwd, statPath, statHdrList)
 
+if os.path.exists('/usr/include/tirpc'):
+   env.Append(  CPPPATH=[ '/usr/include/tirpc']  )
+   LibList = [ 'tirpc' ]
+else:
+   LibList = []
 # actual builds
 envProg = env.Program(target  = procTarget,
-                               source  = [infoProcFileList])
+                               source  = [infoProcFileList],
+                               LIBS = [LibList])
 
 
 # define with absolute path where built files will be copied

--- a/src/procproc/SConstruct
+++ b/src/procproc/SConstruct
@@ -37,7 +37,7 @@ ncommHdrList = [ 'chanLib.h',
                  'shrMLib.h',
                  'sockets.h' ]
 
-SConscript(os.path.join(ncommPath, 'SConstruct'))
+# SConscript(os.path.join(ncommPath, 'SConstruct'))
 
 # source files
 expprocPath     = os.path.join(cwd, os.pardir, 'expproc')

--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -183,7 +183,7 @@ if [ ! -x /usr/bin/dpkg ]; then
   if [ $version -lt 8 ]; then
     commonList="$commonList rsh rsh-server"
   else
-    commonList="$commonList csh libnsl compat-openssl10"
+    commonList="$commonList csh libnsl compat-openssl10 compat-libgfortran-48"
   fi
 
 # Must list 32-bit packages, since these are no longer

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -517,13 +517,9 @@ fi
 
 if [ -e /tmp/.ovj_installed ]; then
    nmr_user=$(/vnmr/bin/fileowner /vnmr/vnmrrev)
-   # temporary fix
-   fixName="/vnmr/adm/users/operators/operatorlist"
-   if [[ -f $fixName ]]; then
-      grep -v ^null$ $fixName > ${fixName}.tmp
-      mv -f ${fixName}.tmp $fixName
-      chown $nmr_user:$nmr_group $fixName
-   fi
+   opFile="/vnmr/adm/users/operators/operatorlist"
+   chown $nmr_user:$nmr_group $opFile
+   chmod 644 $opFile
    echo "Configuring $nmr_user with the standard configuration (stdConf)"
    echo "Configuring $nmr_user with the standard configuration (stdConf)" >> $insLog
    if [ x$distroType = "xdebian" ]; then

--- a/src/stat/SConstruct
+++ b/src/stat/SConstruct
@@ -12,7 +12,7 @@ cwd = os.getcwd()
 
 # library dependancies
 ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
-SConscript(os.path.join(ncommPath, 'SConstruct'))
+# SConscript(os.path.join(ncommPath, 'SConstruct'))
 
 # source files
 vnmrPath     = os.path.join(cwd, os.pardir, 'vnmr')
@@ -47,6 +47,14 @@ statEnv = Environment(CCFLAGS    = '-O -m64',
                       LINKFLAGS  = '-O2 -m64 -Wl,-rpath,/vnmr/lib ',
                       CPPPATH    = [cwd])
 
+if os.path.exists('/usr/include/tirpc'):
+   statEnv.Append(  CPPPATH=[ '/usr/include/tirpc']  )
+   LibList = [ 'm', 'acqcomm', 'tirpc' ]
+   LibList2 = [ 'tirpc' ]
+else:
+   LibList = [ 'm', 'acqcomm' ]
+   LibList2 = []
+
 buildMethods.makeSymLinks(statEnv, infostatTarget, cwd, xracqPath, xracqHdrList)
 buildMethods.makeSymLinks(statEnv, infostatTarget, cwd, acqProcPath, acqProcHdrList)
 buildMethods.makeSymLinks(statEnv, infostatTarget, cwd, vnmrPath, vnmrFileList)
@@ -58,14 +66,14 @@ infostat = statEnv.Program(target  = infostatTarget,
                                       vnmrFileList],
                            LIBPATH = [cwd,
                                       ncommPath],
-                           LIBS    = ['m', 'acqcomm'])
+                           LIBS    = [ LibList ])
 
 showstat = statEnv.Program(target  = showstatTarget,
                            source  = [showStatFileList,
                                       infoServerFileList],
                            LIBPATH = [cwd,
                                       ncommPath],
-                           LIBS    = [])
+                           LIBS    = [ LibList2 ])
 
 # define with absolute path where built files will be copied
 vnmrInstallPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'bin')


### PR DESCRIPTION
Do not rebuild ncomm and dps_ps_gen unnecessarily.
Changes for compatibility with recent OpenVnmrJ changes.
psggen builds 64-bit libraries.