### PR TITLE
fixed seqgen and psggen

### DIFF
--- a/src/bpsg/makeuserpsg.lnx
+++ b/src/bpsg/makeuserpsg.lnx
@@ -58,6 +58,7 @@ PSG_HDR=			\
 		acqparms.h	\
 		allocate.h	\
 		arrayfuncs.h	\
+		b12funcs.h      \
 		cps.h		\
 		CSfuncs.h	\
 		data.h		\
@@ -68,6 +69,7 @@ PSG_HDR=			\
 		params.h	\
 		phase.h		\
 		pvars.h		\
+		shrexpinfo.h	\
 		standard.h	\
 		symtab.h	\
 		tools.h		\

--- a/src/scripts/vnmrseqgen.sh
+++ b/src/scripts/vnmrseqgen.sh
@@ -224,7 +224,7 @@ while [ $# != 0 ]; do
       if [ x$osname = "xLinux" ]; then
          ( make -e -s -f $makefile PS=${file}${dpspost} \
            CPPFLAGS="$incl" \
-           LIB="$psdir" CFLAGS="-O2 -m32 ${Wextra}" LFLAGS="$rpath" \
+           LIB="$psdir" CFLAGS="-O2 -m64 ${Wextra}" LFLAGS="$rpath" \
            SHELL="/bin/sh" DPS_DUMMY_OBJ="$dps_dummy_obj" \
            SEQLIB="$seqlib" psgLinux) 2>> /dev/null
       elif [ x$osname = "xDarwin" ]; then


### PR DESCRIPTION
seqgen still used 32-bit compile in one place
psggen needed to copy some include files to the local psg directory