### PR TITLE
batten did not build in some environments

### DIFF
--- a/src/batten/SConstruct
+++ b/src/batten/SConstruct
@@ -9,7 +9,7 @@ cwd = os.getcwd()
 # get the envirionment
 env = Environment()
 
-env.Execute('gcc -o mcl_RUDAT RUDAT.c libusb/*.c libhid/*.c >& /dev/null')
+env.Execute('gcc -o mcl_RUDAT RUDAT.c libusb/*.c libhid/*.c > /dev/null 2>&1')
 
 # define with absolute path where built files will be copied
 vnmrInstallPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'bin')


### PR DESCRIPTION
If sh is linked to dash rather than bash, then the
redirection >& fails.