### PR TITLE
useAmp is now no longer hardcoded to 0

### DIFF
--- a/src/b12proc/b12proc.c
+++ b/src/b12proc/b12proc.c
@@ -676,7 +676,7 @@ int main (int argc, char *argv[])
                            (double) val[i]/1000.0, i);
             pb_set_amp((double) val[i]/1000.0, i);
 	 }
-	 exps.useAmp = AMP0;
+	 exps.useAmp = num-1; // now no longer hardcoded to 0!
 	 exps.useShape = NO_SHAPE;
       }
       else if ( ! strcmp(r->inst,"SPECTROMETER_FREQUENCY") )

--- a/src/common/maclib/B12SCNControl
+++ b/src/common/maclib/B12SCNControl
@@ -53,7 +53,7 @@ else
     if ($checkValue = 'intamp') then
         tpwrf = 100
     elseif ( $checkValue = 'extamp' ) then
-        tpwrf = 1
+        tpwrf = 3.35
     else
         tpwrf = 1
         write('line3','No communication with SCN possible, set tpwrf to 1 for safety reasons, if in intamp mode use the command tpwrf=100')


### PR DESCRIPTION
useAmp in b12proc is no longer hardcoded to 0

change is tested and allows the use of tpwrf to change the output power