### PR TITLE
Handle tpwrf correctly

### DIFF
--- a/src/bpsg/b12funcs.c
+++ b/src/bpsg/b12funcs.c
@@ -31,9 +31,8 @@ void initPowerVal()
 {
    int i;
 
-   powerVals = 1;
-   powerVal[0] = 1000; // Reg 0 is always hard pulse
-   for (i=1; i < POWER_REGISTERS; i++)
+   powerVals = 0;
+   for (i=0; i < POWER_REGISTERS; i++)
    {
       powerVal[i] = -1;
    }

--- a/src/bpsg/cps.c
+++ b/src/bpsg/cps.c
@@ -213,6 +213,7 @@ void createPS()
        pre_fidsequence();		/* users pre fid functions */
     fprintf(psgFile,"PHASE_RESET 1\n");
     initElems();
+          rlpower(tpwrf,0);
     pulsesequence();	/* generate Acodes from USER Pulse Sequence */
    if (acqtriggers == 0)
    {
@@ -251,7 +252,16 @@ void initparms()
 	nf = 1.0;
     if ( P_getreal(CURRENT,"tpwrf",&tpwrf,1) < 0 )
     {
-        tpwrf = 100.0;                /* if not found assume 0 */
+        tpwrf = 100.0;  // if not found, use max
+    }
+    else if (!var_active("tpwrf",CURRENT))
+    {
+        int size;
+        int i;
+        tpwrf = 100.0;  // if not active, use max
+        P_getsize(CURRENT, "tpwrf", &size);
+        for (i = 2; i<=size; i++)
+           P_setreal(CURRENT, "tpwrf", 100.0, i);
     }
     if ( P_getreal(CURRENT,"rattn",&rattn,1) < 0 )
     {


### PR DESCRIPTION
tpwrf was not being set in "remCnt" section of createPS(). The effect was that arraying tpwrf was not working. Also implemented tpwrf='n' case, which means use full power.