### PR TITLE
mpspower could not be arrayed

### DIFF
--- a/src/bexpproc/mps.c
+++ b/src/bexpproc/mps.c
@@ -534,13 +534,14 @@ void mpsPower(int power)
 {
    char msg[128];
 
-   if ( !mpsCmdOk)
-      return;
    if (power < 0)
    {
-      if (sendMPS("rfstatus 0\n"))
-         return;
-      setMpsRfstatus( 0 );
+      if (mpsCmdOk)
+      {
+         if (sendMPS("rfstatus 0\n"))
+            return;
+         setMpsRfstatus( 0 );
+      }
    }
    else
    {
@@ -548,9 +549,12 @@ void mpsPower(int power)
       if (sendMPS(msg))
          return;
       setMpsPower( power );
-      if (sendMPS("rfstatus 2\n"))
-         return;
-      setMpsRfstatus( 2 );
+      if (mpsCmdOk)
+      {
+         if (sendMPS("rfstatus 2\n"))
+            return;
+         setMpsRfstatus( 2 );
+      }
    }
 }
 


### PR DESCRIPTION
The observation that mpspower could be arrayed if mps='ext' was key to identifying the problem. This should resolve issue #37