### PR TITLE
FID scan would stop prematurely. Infoproc could fail to start.

### DIFF
--- a/src/bexpproc/expproc.c
+++ b/src/bexpproc/expproc.c
@@ -42,6 +42,7 @@ extern int initApplSocket(void);
 extern void restartTasks(void);
 extern void wrtacqinfo2(void);
 extern void getRfSweepDelay();
+extern int chkExpQ(char *argstr);
 
 MSG_Q_ID pRecvMsgQ;
 
@@ -289,6 +290,12 @@ TheGrimReaper(void* arg)
         if (whodied)
 	{
 	   DPRINT1(1,"GrimReaper: '%s' Died.\n",whodied);
+      if ( ! strcmp(whodied,"B12proc") )
+      {
+         DPRINT(1,"Expproc: send chkQ\n");
+         chkExpQ("");
+      }
+
 	}
 	else
 	{

--- a/src/bexpproc/msgehandler.c
+++ b/src/bexpproc/msgehandler.c
@@ -78,6 +78,7 @@ extern int activeQnoWait(int oldproc, long key,        /*  procQfuncs.c */
 extern int expQshow(void);                             /*   expQfuncs.c */
 extern int startB12proc(char *codefile);
 extern void sigInfoproc();
+extern int activeB12proc();
 
 extern char systemdir[];
 extern int rfSweepDwell;
@@ -593,6 +594,11 @@ int chkExpQ(char *argstr)
            DPRINT(1,"chkExpQ: wait on processing, don't start any Q'd Exp.\n");
 	   return(0);   /* active processing is au('wait') don't start any queued Exp. yet */
         }
+     }
+     if (activeB12proc())
+     {
+        DPRINT(1,"chkExpQ: Previous B12proc still active\n");
+        return(0);
      }
 
      if (expQget(&ActiveExpInfo.ExpPriority, ActiveExpInfo.ExpId) != -1)
@@ -2100,6 +2106,10 @@ reserveConsole(char *args)
 	returnInterface = strtok( NULL, "\n" );
 	returnInterface = checkForNoInterface( returnInterface );
 	authInfo = strtok( NULL, "\n" );
+	deliverMessage( returnInterface, "DOWN" );
+	return 0;
+
+
 	modeInteractive = strtok( NULL, "\n" );
 
 	if (authInfo == NULL) {
@@ -2245,6 +2255,8 @@ int releaseConsole(char *args)
 	returnInterface = strtok( NULL, "\n" );
 	returnInterface = checkForNoInterface( returnInterface );
 	authInfo = strtok( NULL, "\n" );
+	deliverMessage( returnInterface, "DOWN" );
+	return( 0 );
 	modeInteractive = strtok( NULL, "\n" );
 
 	if (authInfo == NULL) {
@@ -2657,6 +2669,7 @@ completeStartLock()
 {
 	char	 msge[CONSOLE_MSGE_SIZE], recvmsg[CONSOLE_MSGE_SIZE];
 
+	return 0;
 	sprintf(recvmsg,"startI %s",ActiveExpInfo.ExpId);
   	DPRINT1(1,"Send Recvproc: '%s'\n",recvmsg);
 	deliverMessage( "Recvproc", recvmsg );
@@ -2674,6 +2687,7 @@ completeStartFID()
 	        recvmsg[CONSOLE_MSGE_SIZE],
 		sndmsge[2*CONSOLE_MSGE_SIZE];
 
+	return 0;
 	DPRINT( 1, "complete start FID called\n" );
 
 /* Send Recvproc its message first  */

--- a/src/bexpproc/prochandler.c
+++ b/src/bexpproc/prochandler.c
@@ -103,6 +103,11 @@ int startAutoproc(char *autodir, char *autoDoneQ)  /* if not started then start 
     }
 }
 
+int activeB12proc()
+{
+   return(taskList[B12PROC].taskPid != -1);
+}
+
 int startB12proc(char *codefile)
 {
    char testpath[512];

--- a/src/infoproc/info_svc.c
+++ b/src/infoproc/info_svc.c
@@ -352,10 +352,12 @@ acqinfo_svc()
     * what our port number is
     */
    transp->xp_port = htons(transp->xp_port);
+   // Failure to register disables distributed ft3d processing and
+   // remote acqstat. Should not be a problem for B12
    if (!svc_register(transp, prog_num, prog_ver, acqinfoprog_2, IPPROTO_TCP))
    {
       (void) fprintf(stderr, "Error: unable to register (ACQINFOPROG, ACQINFOVERS, tcp).\n");
-      exit(1);
+      // exit(1);
    }
 
    // Tell Expproc that Infoproc is ready for signals.


### PR DESCRIPTION
There was a race between starting a new B12proc due to an au call from wexp processing and the exit of the B12proc that initiated the wexp processing. This resulted in the new B12proc failing to start and the FID scan stopping. Now, if the previous B12proc has not yet exited by the time the new B12proc is requested, a new B12proc will be started upon receiving the SIGCHLD from the exiting B12proc.

Infoproc would exit if it failed to set up the rpc server system. This is only used for distributed ft3d processing and the obsolete remote Acqstat display. Neither of these are an issue for B12 so the exit was removed.